### PR TITLE
fix: updated failing unit test

### DIFF
--- a/src/__tests__/datepicker.test.js
+++ b/src/__tests__/datepicker.test.js
@@ -627,6 +627,8 @@ describe('Date picker', () => {
     it('should default focus day to min date when input dates are before min date', () => {
       const yesterdayMinusOne = new Date();
       yesterdayMinusOne.setDate(yesterday.getDate() - 1);
+      yesterdayMinusOne.setMonth(yesterday.getMonth());
+      yesterdayMinusOne.setFullYear(yesterday.getFullYear());
 
       datePicker(document.querySelector('.date-picker'), {
         minDate: yesterday,


### PR DESCRIPTION
`yesterdayMinusOne` was being used as a test date but only its day is updated. Therefore on the first of every month it is likely we would of seen this failing. 