### PR TITLE
refactor: remove id from icon construction

### DIFF
--- a/src/demo.js
+++ b/src/demo.js
@@ -32,5 +32,5 @@ datePicker(document.querySelector('.date-picker-style-two'), {
 });
 
 datePicker(document.querySelector('.date-picker-icon'), {
-  icon: CalendarIcon,
+  icon: `${CalendarIcon}#calendar_today`,
 });

--- a/src/js/datepicker.js
+++ b/src/js/datepicker.js
@@ -927,7 +927,7 @@ function datePicker(datePickerElement, options = {}) {
 
   function getCalendarIconTemplate() {
     return `<span class="sr-only">${content[state.language].buttons.dialogTrigger}</span>
-            <svg aria-hidden="true" role="img"><use href="${options.icon}#calendar_today"></use></svg>`;
+            <svg aria-hidden="true" role="img"><use href="${options.icon}"></use></svg>`;
   }
 
   function isDatesEqual(dateA, dateB) {


### PR DESCRIPTION
### Changes:
* remove `calendar_today` id from icon construction, this can be left to the consumer to define if they wish