### PR TITLE
chore: update parse inputs cb naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ datePicker(selector, {
 
 The datepicker currently supports the following optional callbacks
 
-### parseInputs
+### onParseInputs
 
 A callback that accepts 3 inputs: `day`, `month`, `year` which are taken from the input elements.
 You can then manipulate these inputs and return an object with the following structure:
@@ -192,7 +192,7 @@ This returned object is then validated and used to set the focused date upon ope
 Using it in your code:
 ```javascript
 datePicker(selector, options, {
-  parseInputs: function(day, month, year) {
+  onParseInputs: function(day, month, year) {
     // some minpulation logic
     var manipulatedDay, manipulatedMonth, manipulatedYear;
     return {

--- a/src/__tests__/datepicker.test.js
+++ b/src/__tests__/datepicker.test.js
@@ -1040,7 +1040,7 @@ describe('Date picker', () => {
         document.querySelector('.date-picker'),
         {},
         {
-          parseInputs: (day, month, year) => ({ day, month, year: `20${year}` }),
+          onParseInputs: (day, month, year) => ({ day, month, year: `20${year}` }),
         },
       );
 

--- a/src/js/datepicker.js
+++ b/src/js/datepicker.js
@@ -128,8 +128,8 @@ function datePicker(datePickerElement, options = {}, callbacks = {}) {
       year: elements.inputs.year.value,
     };
 
-    if (callbacks.parseInputs) {
-      inputDates = callbacks.parseInputs(inputDates.day, inputDates.month, inputDates.year);
+    if (callbacks.onParseInputs) {
+      inputDates = callbacks.onParseInputs(inputDates.day, inputDates.month, inputDates.year);
     }
 
     function isValidInput(input) {


### PR DESCRIPTION
**Changes**

Updates callback naming from `parseInputs` to `onParseInputs`. 