### PR TITLE
refactor: move govuk-frontend to a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ See a preview [here](https://still-headland-16463.herokuapp.com)
 ### Table of Contents
 
 * [Installation](#installation)
-* [Dependencies](#Dependencies)
 * [Basic Usage](#basic-usage)
 * [Configuration options](#options)
 * [Callbacks](#callbacks)
@@ -32,10 +31,6 @@ Files & locations:
 | datepicker.min.js  | node_modules/kainos-govuk-datepicker/dist     | production build - (ES5, 14kb) |
 | datepicker.min.css | node_modules/kainos-govuk-datepicker/dist     | production stylesheet          |
 | datepicker.scss    | node_modules/kainos-govuk-datepicker/src/scss | SCSS file for use in builds    |
-
-## Dependencies
-
-The date picker has only one dependency i.e. [govuk-frontend](https://www.npmjs.com/package/govuk-frontend) ^3.14.0
 
 ## Basic Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5581,7 +5581,8 @@
     "govuk-frontend": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
+      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jest": "^25.2.2",
     "express": "^4.17.1",
+    "govuk-frontend": "^3.14.0",
     "html-webpack-plugin": "^5.5.0",
     "husky": "^7.0.4",
     "jest": "^28.1.3",
@@ -50,9 +51,6 @@
     "webpack": "^5.63.0",
     "webpack-cli": "^4.9.1",
     "webpack-merge": "^5.8.0"
-  },
-  "dependencies": {
-    "govuk-frontend": "^3.14.0"
   },
   "jest": {
     "testPathIgnorePatterns": [


### PR DESCRIPTION
* move dependency to the dev dependency
  * It is only used in the demo features and as such shouldn't be marked as a requirement for the tool